### PR TITLE
Modificación para verificación de argumentos

### DIFF
--- a/nsniffer
+++ b/nsniffer
@@ -196,6 +196,14 @@ extract_pcap() {
 }
 
 
+check_arguments(){
+	    if [[ $# -le 2 ]]; then
+        print_with_color "\n$error" "Statement incomplete.\n"
+        print_help
+        exit 1
+        fi
+}
+
 main() {
   if [ "$(id -u)" -ne 0 ]; then
     print_with_color "$error" "This script must be run as root."
@@ -217,14 +225,17 @@ main() {
   while [[ $# -gt 0 ]]; do
     case $1 in
       -i|--interface)
+      	check_arguments "$@"
         interface=$2
         shift 2
         ;;
       -o|--output)
+      	check_arguments "$@"
         output_file=$2
         shift 2
         ;;
       -f|--filter)
+      	check_arguments "$@"
         filter=$2
         shift 2
         ;;
@@ -237,12 +248,14 @@ main() {
         shift
         ;;
       -m|--mitm)
+      	check_arguments "$@"
         target1=$2
         target2=$3
         mitm=true
         shift 3
         ;;
       -arp|--arp)
+      	check_arguments "$@"
         target1=$2
         target2=$3
         arpspoof=true
@@ -265,6 +278,7 @@ main() {
         exit 0
         ;;
       -g|--log)
+      	check_arguments "$@"
         log_file=$2
         capture_and_log "$interface" "$log_file"
         exit 0


### PR DESCRIPTION
Añadí una función algo tocha para que de un aviso cuando no pongas todos los argumentos.

Ejemplo: Si pongo solo `nsniffer -i`, da un error de bash que el valor $2 esta vacio.
![image](https://github.com/user-attachments/assets/b6517401-e980-4da4-a0c9-07e2a77c88cc)

LA función verifica si se recibieron menos de 2 argumentos. Si es así, dara un error.
![image](https://github.com/user-attachments/assets/1ecb8f7c-644f-436a-96b6-100c0d4f1fe6)

Prueba a ver si funciona bien.